### PR TITLE
Fix OOM caused by Pool's uncleaned _destroyedObjects set

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -97,6 +97,7 @@ public class Pool<K,V> implements IPool<K,V> {
             }
 
             if (_destroyedObjects.contains(obj)) {
+                _destroyedObjects.remove(obj);
                 objects.decrementAndGet();
                 _lock.unlock();
                 destroy(obj);


### PR DESCRIPTION
We have an Aleph-based HTTP client and after few days of work it fails with `OutOfMemoryError`. Initial investigation with the [MAT](https://eclipse.org/mat/) shows that most of the heap is used by the [`io.aleph.dirigiste.Pool::_destroyedObjects`](https://github.com/ztellman/dirigiste/blob/c08a997fe8fc72a3e5d82edd02fd8627de6cc387/src/io/aleph/dirigiste/Pool.java#L204): 

![MAT screenshot](http://i.imgur.com/BHce8mU.png)

I'm not 100% sure, but after a quick look over the `dirigiste`'s source it seems that after the [`dispose`](https://github.com/ztellman/dirigiste/blob/c08a997fe8fc72a3e5d82edd02fd8627de6cc387/src/io/aleph/dirigiste/Pool.java#L439) of the failed connection in case [it's already been taken](https://github.com/ztellman/dirigiste/blob/c08a997fe8fc72a3e5d82edd02fd8627de6cc387/src/io/aleph/dirigiste/Pool.java#L449) connection [won't be added](https://github.com/ztellman/dirigiste/blob/c08a997fe8fc72a3e5d82edd02fd8627de6cc387/src/io/aleph/dirigiste/Pool.java#L103) back to the queue (so that it could be [cleaned](https://github.com/ztellman/dirigiste/blob/c08a997fe8fc72a3e5d82edd02fd8627de6cc387/src/io/aleph/dirigiste/Pool.java#L127) later) and it's not removed from the `_destroyedObjects` manually, so it remains in that set until pool is stopped.

I've added the explicit remove of connection from the `_destroyedObjects` for the described case, but didn't test it thoroughly (i. e., not sure it really fixes the OOM).