### PR TITLE
Fix memory leak in Executor

### DIFF
--- a/src/io/aleph/dirigiste/Executor.java
+++ b/src/io/aleph/dirigiste/Executor.java
@@ -78,7 +78,7 @@ public class Executor extends AbstractExecutorService {
                         } catch (InterruptedException e) {
 
                         }
-                        _workers.remove(this);
+                        _workers.remove(Worker.this);
                         _latch.countDown();
                     }
                 };


### PR DESCRIPTION
The `this` in the anonymous `Runnable` refers to the `Runnable`, not the `Worker` it belongs to. So, workers were not actually being removed from the `Executor._workers` list.

Background: I noticed a memory leak while using aleph 0.4.1 with the default utilization executor to handle millions of long polling requests per day. Examining heap dumps pointed to the `Executor._workers` list being the culprit, as `Worker` instances were never being removed (despite `_isShutdown` being true and `_latch` having counted down to 0).