### PR TITLE
Properly shutdown/shutdownNow the executor

### DIFF
--- a/test/dirigiste/executor_test.clj
+++ b/test/dirigiste/executor_test.clj
@@ -5,12 +5,14 @@
     [java.util
      EnumSet]
     [java.util.concurrent
+     RejectedExecutionException
      CountDownLatch
      SynchronousQueue
      TimeUnit]
     [io.aleph.dirigiste
      Executors
      Executor
+     Executor$Controller
      Stats$Metric]))
 
 (defn run-producer [^java.util.concurrent.Executor ex n interval]
@@ -65,3 +67,70 @@
 
 (deftest ^:stress test-utilization-metric
   )
+
+(defn- shutdown-task [times task-timeout-ms]
+  (let [res (atom 0)]
+    [res (fn [] (loop [cnt 1]
+                  (swap! res inc)
+                  (Thread/sleep task-timeout-ms)
+                  (when (< cnt times)
+                    (recur (inc cnt)))))]))
+
+(defn- check-shutdown-after [ex task-timeout-ms]
+  (let [times 3
+        [res task] (shutdown-task times task-timeout-ms)]
+    (.execute ex task)
+    (Thread/sleep 10)
+    (.shutdown ex)
+    (is (= 1 @res))
+
+    (Thread/sleep (+ 10 (* task-timeout-ms times)))
+    (is (= times @res))
+
+    (is (thrown? RejectedExecutionException
+                 (.execute ex task)))
+    (Thread/sleep (+ task-timeout-ms 10))
+    (is (= times @res))
+
+    (is (.isShutdown ex))
+    (is (.isTerminated ex))))
+
+(defn- check-shutdown-now-after [ex task-timeout-ms]
+  (let [times 3
+        [res task] (shutdown-task times task-timeout-ms)]
+    (.execute ex task)
+    (Thread/sleep 10)
+    (is (= 1 (count (.shutdownNow ex))))
+    (is (= 1 @res))
+
+    ;; task must have been interrupted
+    (Thread/sleep (+ 10 (* task-timeout-ms (inc times))))
+    (is (= 1 @res))
+
+    (is (thrown? RejectedExecutionException
+                 (.execute ex task)))
+    (Thread/sleep (+ task-timeout-ms 10))
+    (is (= 1 @res))
+
+    (is (.isShutdown ex))
+    (is (.isTerminated ex))))
+
+(defn- custom-fixed-executor [controller]
+  (Executor. (java.util.concurrent.Executors/defaultThreadFactory)
+             (java.util.concurrent.SynchronousQueue. false)
+             controller 1 (EnumSet/noneOf Stats$Metric)
+             10 100 TimeUnit/MILLISECONDS))
+
+(deftest shutdown-custom-fixed-executor
+  (let [controller (Executors/fixedController 1)]
+    (check-shutdown-now-after (custom-fixed-executor controller) 30)
+    (check-shutdown-after (custom-fixed-executor controller) 30)))
+
+(deftest shutdown-manifold-fixed-executor
+  (let [controller (reify Executor$Controller
+                     (shouldIncrement [_ n]
+                       (< n 1))
+                     (adjustment [_ s]
+                       (- 1 (.getNumWorkers s))))]
+    (check-shutdown-now-after (custom-fixed-executor controller) 30)
+    (check-shutdown-after (custom-fixed-executor controller) 30)))


### PR DESCRIPTION
Previously `execute` happily accepted new tasks after the executor was shut down. This patch brings it in line with other `java.util.concurrent` Executors.

Also `shutdownNow` didn't set the `_shutdown` flag properly.