### PR TITLE
Remove constructors usage of Long, Integer & Double

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -401,7 +401,7 @@ public class Pool<K,V> implements IPool<K,V> {
                         // do all the latency bookkeeping
                         long acquire = System.nanoTime();
                         _queueLatencies.sample(key, acquire - start);
-                        _start.put(obj, new Long(start));
+                        _start.put(obj, start);
 
                         callback.handleObject(obj);
                     }

--- a/src/io/aleph/dirigiste/Pools.java
+++ b/src/io/aleph/dirigiste/Pools.java
@@ -43,7 +43,7 @@ public class Pools {
                     double correction = s.getUtilization(1.0) / targetUtilization;
                     int n = (int) Math.ceil(s.getNumWorkers() * correction) - numWorkers;
 
-                    adj.put(entry.getKey(), new Integer(n));
+                    adj.put(entry.getKey(), n);
                 }
                 return adj;
             }

--- a/src/io/aleph/dirigiste/Stats.java
+++ b/src/io/aleph/dirigiste/Stats.java
@@ -156,7 +156,7 @@ public class Stats {
         }
 
         if (t < 0 || 1 < t) {
-            throw new IllegalArgumentException(new Double(t).toString());
+            throw new IllegalArgumentException(Double.toString(t));
         }
 
         int cnt = vals.length;
@@ -183,7 +183,7 @@ public class Stats {
         }
 
         if (t < 0 || 1 < t) {
-            throw new IllegalArgumentException(new Double(t).toString());
+            throw new IllegalArgumentException(Double.toString(t));
         }
 
         int cnt = vals.length;


### PR DESCRIPTION
Hi,

I started analysing Dirigiste Java code with [SonarQube](https://www.sonarqube.org/) static code analysis (hint: it's an awesome tool) hoping it would suggest pieces of code that could explain the OutOfMemory errors I encounter with aleph (https://github.com/ztellman/aleph/issues/394).

It hasn't found anything blocking, but there are some code smells that you might want to fix. Here is a first one.

Constructors of objects used to wrap primitives are discouraged. When applicable, Java uses auto-boxing internally (that it, is converts primitives types to objects types by itself).

Using such constructors is also known to use more memory since they force the creation of new objects (versus using JVM caches of frequent values).

More explanations are available under https://rules.sonarsource.com/java/type/Bug/RSPEC-2129 .