### PR TITLE
Pool: don't store _stats as instance field anymore

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -242,17 +242,7 @@ public class Pool<K,V> implements IPool<K,V> {
         Map<K,double[]> taskRejectionRates = _taskRejectionRates.toMap();
 
         final Set<K> keys = _queues.keySet();
-
-        // compute HashMap initial capacity to keep the map from being
-        // resized while we put elements
-        // 0.75 is the default load factor
-        final int mapCapacity;
-        if (keys.size() < 3) {
-            mapCapacity = keys.size() + 1;
-        } else {
-            mapCapacity = (int) ((float) keys.size() / 0.75F + 1.0F);
-        }
-        final Map<K,Stats> stats = new HashMap<K,Stats>(mapCapacity);
+        final Map<K,Stats> stats = new HashMap<K,Stats>(Stats.hashMapCapacity(keys.size()));
 
         for (K key : keys) {
             stats.put(key,

--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -241,8 +241,20 @@ public class Pool<K,V> implements IPool<K,V> {
         Map<K,double[]> taskCompletionRates = _taskCompletionRates.toMap();
         Map<K,double[]> taskRejectionRates = _taskRejectionRates.toMap();
 
-        Map<K,Stats> stats = new HashMap<K,Stats>();
-        for (K key : _queues.keySet()) {
+        final Set<K> keys = _queues.keySet();
+
+        // compute HashMap initial capacity to keep the map from being
+        // resized while we put elements
+        // 0.75 is the default load factor
+        final int mapCapacity;
+        if (keys.size() < 3) {
+            mapCapacity = keys.size() + 1;
+        } else {
+            mapCapacity = (int) ((float) keys.size() / 0.75F + 1.0F);
+        }
+        final Map<K,Stats> stats = new HashMap<K,Stats>(mapCapacity);
+
+        for (K key : keys) {
             stats.put(key,
                       new Stats(EnumSet.allOf(Stats.Metric.class),
                                 queue(key).objects.get(),

--- a/src/io/aleph/dirigiste/Pools.java
+++ b/src/io/aleph/dirigiste/Pools.java
@@ -34,7 +34,7 @@ public class Pools {
             }
 
             public Map adjustment(Map stats) {
-                Map adj = new HashMap();
+                final Map adj = new HashMap(Stats.hashMapCapacity(stats.size()));
 
                 for (Object e : stats.entrySet()) {
                     Map.Entry entry = (Map.Entry) e;

--- a/src/io/aleph/dirigiste/Stats.java
+++ b/src/io/aleph/dirigiste/Stats.java
@@ -24,6 +24,23 @@ public class Stats {
 
     private static final int RESERVOIR_SIZE = 4096;
 
+    /**
+     * Compute HashMap capacity that allow a HashMap to keep expectedSize items without
+     * having to resize its internal data structure.
+     *
+     * This assumes that the default load factor (0.75) is used.
+     *
+     * @param expectedSize number of items to put in HashMap
+     * @return capacity
+     */
+    static int hashMapCapacity(int expectedSize) {
+        if (expectedSize < 3) {
+            return ++expectedSize;
+        } else {
+            return (int) ((float) expectedSize / 0.75F + 1.0F);
+        }
+    }
+
     public static class UniformLongReservoir {
 
         private final AtomicInteger _count = new AtomicInteger();


### PR DESCRIPTION
Since it's only used within startControlLoop() method, we don't store the gathered stats at the Pool level anymore to reduce memory usage.

At the same time, we remove the unused samlesPerSecond variable within startControlLoop() method.