### PR TITLE
Remove unused stats

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -325,6 +325,15 @@ public class Pool<K,V> implements IPool<K,V> {
                         if (entry.getValue().getUtilization(1) == 0
                             && _queues.get(key).objects.get() == 0) {
                             _queues.remove(key).shutdown();
+
+                            // clean up stats so they don't remain in memory forever
+                            _queueLatencies.remove(key);
+                            _taskLatencies.remove(key);
+                            _queueLengths.remove(key);
+                            _utilizations.remove(key);
+                            _taskArrivalRates.remove(key);
+                            _taskCompletionRates.remove(key);
+                            _taskRejectionRates.remove(key);
                         }
                     }
                     _lock.unlock();

--- a/src/io/aleph/dirigiste/Stats.java
+++ b/src/io/aleph/dirigiste/Stats.java
@@ -240,7 +240,7 @@ public class Stats {
     private final long[] _queueLatencies;
     private final long[] _taskLatencies;
 
-    public static Stats EMPTY = new Stats(EnumSet.noneOf(Metric.class), 0, new double[] {}, new double[] {}, new double[] {}, new double[] {}, new long[] {}, new long[] {}, new long[] {});
+    public static final Stats EMPTY = new Stats(EnumSet.noneOf(Metric.class), 0, new double[] {}, new double[] {}, new double[] {}, new double[] {}, new long[] {}, new long[] {}, new long[] {});
 
     public Stats(EnumSet<Metric> metrics, int numWorkers, double[] utilizations, double[] taskArrivalRates, double[] taskCompletionRates, double[] taskRejectionRates, long[] queueLengths, long[] queueLatencies, long[] taskLatencies) {
         _metrics = metrics;

--- a/src/io/aleph/dirigiste/Stats.java
+++ b/src/io/aleph/dirigiste/Stats.java
@@ -116,6 +116,10 @@ public class Stats {
             }
             return m;
         }
+
+        public void remove(K key) {
+            _reservoirs.remove(key);
+        }
     }
 
     public static class UniformDoubleReservoirMap<K> {
@@ -138,6 +142,10 @@ public class Stats {
                 m.put(k, _reservoirs.remove(k).toArray());
             }
             return m;
+        }
+
+        public void remove(K key) {
+            _reservoirs.remove(key);
         }
     }
 


### PR DESCRIPTION
This PR introduces 2 changes to reduce memory usage:
- the Pool `_stats` instance variable, which keeps a copy of the pool statistics, is removed as it is not needed.
- Statistics for queues that are evicted from the pool are not kept in memory anymore.

I think I have put this code at the right location, I'm now running it on my testing environment so I'll report if memory usage now remains under control.