### PR TITLE
Report completed tasks when releasing the object to pool

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -448,7 +448,7 @@ public class Pool<K,V> implements IPool<K,V> {
 
         if (start != null) {
             _taskLatencies.sample(key, end - start.longValue());
-            queue(key).put(obj);
+            queue(key).release(obj);
         }
     }
 


### PR DESCRIPTION
The current version of Pool never reports completed tasks because in `Pool.release` method it calls `Queue.put` directly instead of `Queue.release`. Only the latter bumps `completed` counter.

This bug misrepresents the completion rate in stats (taskCompletionRate is always zero) and screws up the utilization heuristics.