### PR TITLE
Fix how utilization is calculated for pools

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -30,6 +30,10 @@ public class Pool<K,V> implements IPool<K,V> {
             return _takes.size();
         }
 
+        public int availableObjectsCount() {
+            return _puts.size();
+        }
+
         public void cancelTake(AcquireCallback<V> take) {
             _takes.remove(take);
         }
@@ -305,7 +309,8 @@ public class Pool<K,V> implements IPool<K,V> {
                     _taskRejectionRates.sample(key, rejected);
 
                     int queueLength = q.getQueueLength();
-                    double utilization = (double) (queueLength > 0 ? (objects + queueLength) : (incoming - completed)) / Math.max(1, objects);
+                    int available = q.availableObjectsCount();
+                    double utilization = 1.0 - ((available - queueLength) / Math.max(1.0, objects));
                     _utilizations.sample(key, utilization);
                 }
 


### PR DESCRIPTION
I thought #21 is going to fix my issues with how utilization is measured, but it didn't, so I dug a bit more.

With the current utilization calculating code, I've been getting this weird behavior when the pool was upscaled/downscaled violently on each control cycle. Basically, it looks like this:

<img width="1174" alt="screen shot 2018-11-19 at 15 00 45" src="https://user-images.githubusercontent.com/468477/48708872-74509180-ec0c-11e8-989a-d7e91dcae386.png">

The utilization constantly alternates between >1 (when there was at least one pending take throughout the control period) and ~0.03 (when there were no pending takes). Such utilization values make the number of workers jump from 2k to 8k and back 2k every ten seconds (`:target-utilization` is configured at 0.5).

So, I tracked the issue back to the place where utilization is calculated: https://github.com/ztellman/dirigiste/blob/64b36bfb38294953eb3acb3b817a8993782122c8/src/io/aleph/dirigiste/Pool.java#L308

For cases when `queueLength > 0` it does a sensible thing: utilization is indeed roughly `1 + requiredExtraObjects / totalObjects`. However, in the opposite case, we want to track utilization as `objectsInUse / totalObjects`. And you can in theory calculate it as `incoming - completed` (which is how it is done now) but only if you take these numbers each time from the very creation of the pool to now. Instead, they are reset to zero on each sample iteration, which means that in fact it calculates:

![](https://latex.codecogs.com/gif.latex?%7B%5Cdelta%20N_%7Bincoming%7D%20%5Cover%20%5Cdelta%20t%7D%20-%20%7B%5Cdelta%20N_%7Bcompleted%7D%20%5Cover%20%5Cdelta%20t%7D)

And that is not momentary utilization but utilization changing speed! There is an unnecessary derivation here :).

The suggested fix defines utilization as `1 - ((avaiableObjects - pendingTakes) / totalObjects)` where the number of available objects is obtained from the length of the pending puts queue. With this fix, my connection pool has become much more stable and robust.

As a side question to this, is there a reason why the utilization of pools is not calculated in the same was as for executors, i.e. `totalInUseTime / elapsedTime`? We track task latency for pools already, so all the required data is there.