### PR TITLE
[pools] Allow adjustment by 1

### DIFF
--- a/src/io/aleph/dirigiste/Pool.java
+++ b/src/io/aleph/dirigiste/Pool.java
@@ -355,7 +355,7 @@ public class Pool<K,V> implements IPool<K,V> {
                                 q.drop();
                             }
                             q.cleanup();
-                        } else if (n > 1) {
+                        } else if (n > 0) {
                             for (int i = 0; i < n; i++) {
                                 upward.add(entry.getKey());
                             }


### PR DESCRIPTION
I assume this is not intentional – pool will not adjust upwards if the adjustment value for a key is exactly 1. Not critical, but slightly annoying.